### PR TITLE
Pads without single buf

### DIFF
--- a/lua/centerpad.lua
+++ b/lua/centerpad.lua
@@ -24,6 +24,12 @@ local turn_on = function(config)
   vim.cmd(string.format('%svnew', config.leftpad))
   local leftpad = v.nvim_get_current_buf()
   v.nvim_buf_set_name(leftpad, 'leftpad')
+
+  -- Switch to leftpad and fix its width
+  local leftpad_win = v.nvim_get_current_win()
+  v.nvim_set_current_win(leftpad_win)
+  v.nvim_win_set_option(leftpad_win, "winfixwidth", true)
+
   v.nvim_set_current_win(main_win)
 
   -- create scratch window to the right
@@ -31,6 +37,12 @@ local turn_on = function(config)
   vim.cmd(string.format('%svnew', config.rightpad))
   local rightpad = v.nvim_get_current_buf()
   v.nvim_buf_set_name(rightpad, 'rightpad')
+
+  -- Switch to rightpad and fix its width
+  local rightpad_win = v.nvim_get_current_win()
+  v.nvim_set_current_win(rightpad_win)
+  v.nvim_win_set_option(rightpad_win, "winfixwidth", true)
+
   v.nvim_set_current_win(main_win)
 
   -- keep track of the current state of the plugin

--- a/lua/centerpad.lua
+++ b/lua/centerpad.lua
@@ -7,50 +7,37 @@ local turn_on = function(config)
   -- Get reference to current_buffer
   local main_win = v.nvim_get_current_win()
 
-  -- get the user's current options for split directions
-  local useropts = {
-    splitbelow = vim.o.splitbelow,
-    splitright = vim.o.splitright,
-  }
-
-  -- Make sure that the user doesn't have more than one window/buffer open at the moment
-  if #v.nvim_tabpage_list_wins(0) > 1 then
-    print('Please only have one window and buffer open')
-    return
-  end
-
   -- create scratch window to the left
-  vim.o.splitright = false
   vim.cmd(string.format('%svnew', config.leftpad))
+  vim.cmd('wincmd H')
+  
   local leftpad = v.nvim_get_current_buf()
   v.nvim_buf_set_name(leftpad, 'leftpad')
 
   -- Switch to leftpad and fix its width
   local leftpad_win = v.nvim_get_current_win()
   v.nvim_set_current_win(leftpad_win)
+  v.nvim_win_set_width(leftpad_win, config.leftpad)
   v.nvim_win_set_option(leftpad_win, "winfixwidth", true)
 
   v.nvim_set_current_win(main_win)
 
   -- create scratch window to the right
-  vim.o.splitright = true
   vim.cmd(string.format('%svnew', config.rightpad))
+  vim.cmd('wincmd L')
   local rightpad = v.nvim_get_current_buf()
   v.nvim_buf_set_name(rightpad, 'rightpad')
 
   -- Switch to rightpad and fix its width
   local rightpad_win = v.nvim_get_current_win()
   v.nvim_set_current_win(rightpad_win)
+  v.nvim_win_set_width(rightpad_win, config.rightpad)
   v.nvim_win_set_option(rightpad_win, "winfixwidth", true)
 
   v.nvim_set_current_win(main_win)
 
   -- keep track of the current state of the plugin
   vim.g.center_buf_enabled = true
-
-  -- reset the user's split opts
-  vim.o.splitbelow = useropts.splitbelow
-  vim.o.splitright = useropts.splitright
 end
 
 -- function to toggle zen mode off


### PR DESCRIPTION
You can now call `:Centerpad` without the need for there to only be one buffer. This is accomplished by creating splits and then using `vim.cmd("wincmd L")` to move the splits all the way to the left and right.